### PR TITLE
fix(build): prevent infinite loops on builded project

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -267,15 +267,21 @@ gulp.task('cssmin', function () {
 });
 
 gulp.task('scripts', function () {
-  var tpl = gulp.src('client/views/**/*.html')
+  var views = gulp.src('client/views/**/*.html')
     .pipe($.angularTemplatecache({
       root: 'views',
       module: 'soundgether'
     }));
 
+  var tpls = gulp.src('client/directives/**/*.html')
+    .pipe($.angularTemplatecache({
+      root: 'directives',
+      module: 'soundgether'
+    }));
+
   var app = gulp.src('dist/client/app.js');
 
-  return sq({ objectMode: true }, app, tpl)
+  return sq({ objectMode: true }, app, views, tpls)
     .pipe($.concat('app.js'))
     .pipe($.ngAnnotate())
     .pipe($.uglify())


### PR DESCRIPTION
In case your wondering why your `build` or `preview` is failing with an infinite loop error, that was the mistake on our side.

We try to keep the old customers up-to-date with important fixes, but we **strongly** advice you to re-deploy your project with the latest **Bangular** and copy your core files.

_Remember that your premium subscription will soon end and that we might withdraw an undetermined amount of money from your bank account to keep your privilegied status._
